### PR TITLE
fix: add docs for timestamp key constraint

### DIFF
--- a/zh_CN/sql-reference/statements/create.md
+++ b/zh_CN/sql-reference/statements/create.md
@@ -21,11 +21,13 @@ CREATE TABLE [IF NOT EXISTS] [database.]table_name
     column_name data_type [column_constraint] [ DEFAULT default_expr ]，
     ...
     ...
+    timestamp key (ts_column_name)
 )
 PARTITION BY HASH(expr) PARTITIONS PARTITOIN_NUM
 ENGINE=TimeSeries
 with(k=v,k1=v1)
 ```
+对于时序（TimeSeries）引擎，至少有一个列需要为 **TIMESTAMP** 类型，且必须使用 `timestamp key` 语句来指定唯一的 timestamp key 列，这个列的类型必须为 **TIMESTAMP**。
 
 ::: tip
 针对非 **TIMESTAMP** 类型，默认值只支持常量设置。针对 **TIMESTAMP** 类型，默认值除了常量外还支持输出`CURRENT_TIMESTAMP`，在写入数据时如果没有给出时间戳值将会使用写入时间。
@@ -38,6 +40,7 @@ CREATE TABLE sx1(
     sid INT32,
     value REAL,
     flag INT8,
+    timestamp key (ts),
     )
 PARTITION BY HASH(sid) PARTITIONS 1
 ENGINE=TimeSeries

--- a/zh_CN/sql-reference/table-engine-timeseries.md
+++ b/zh_CN/sql-reference/table-engine-timeseries.md
@@ -10,7 +10,7 @@ CREATE TABLE [IF NOT EXISTS] [database.]table_name
     name1 type1 [ DEFAULT default_expr ],
     name2 type2 [ DEFAULT default_expr ] ,
     ...
-    TIMESTAMP KEY expr,
+    TIMESTAMP KEY (expr),
     ...
 )
 PARTITION BY HASH(column_name) PARTITIONS 2
@@ -19,7 +19,7 @@ PARTITION BY HASH(column_name) PARTITIONS 2
 ```
 
 **说明**  
-* TIMESTAMP KEY: 用户必须指定 `TIMESTAMP KEY`，TIMESTAMP KEY 字段必须为 `TIMESTAMP` 类型。
+* TIMESTAMP KEY: 用户必须指定唯一的 `TIMESTAMP KEY`，TIMESTAMP KEY 字段必须为 `TIMESTAMP` 类型。
 * ENGINE: 用于指定表引擎，时序引擎为: TimeSeries。
 * PARTITION: 在时序引擎中，一般将数据源唯一标识作为 partition key，并通过  PARTITIONS 设置分区数量(合理的设计分区数量有利于提升性能)。
 * 创建表时可以通过`WITH`参数对表进行配置。  


### PR DESCRIPTION
- 修改了 create table 页面的内容，添加了对于时序引擎，必须使用 timestamp key 语句来指定 timestamp key column 的文档。
- 修改了时序引擎页面的内容，修正了 timestamp key 语句的语法，将 `TIMESTAMP KEY expr` 修正为 `TIMESTAMP KEY (expr)`，并添加了 timestamp key column  有且只能有一个的描述。